### PR TITLE
Update minecraft-protocol

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "license": "ISC",
   "dependencies": {
     "fs": "0.0.1-security",
-    "minecraft-protocol": "^1.22.0",
+    "minecraft-protocol": "^1.25.0",
     "moment": "^2.29.1"
   }
 }


### PR DESCRIPTION
That will expand the current Minecraft versions supported, since the older version couldn't support 1.16.5